### PR TITLE
Decomposition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 install:
   - stack --no-terminal --install-ghc test --only-dependencies
 script:
-  - stack --no-terminal test --haddock --no-haddock-deps --test-arguments --threads=1
+  - stack --no-terminal test --haddock --no-haddock-deps
 notifications:
   email: false
   irc:

--- a/src/UnionSums.hs
+++ b/src/UnionSums.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module UnionSums (unionSumTypes, mkConverter) where
+module UnionSums (unionSumTypes, mkConverter, mkDecompose) where
 
 import Control.Error.Util
-import Control.Monad (join)
+import Control.Monad (join, zipWithM)
 import Data.Char (toLower)
 import Data.Maybe (fromJust)
 import Data.Text (pack, unpack)
@@ -74,3 +74,37 @@ stripSuffix suf = fmap unpack . Text.stripSuffix (pack suf) . pack
 
 lowerFirst :: String -> String
 lowerFirst (c:s) = toLower c : s
+
+replace :: Int -> a -> [a] -> [a]
+replace i a as = go 0 as
+  where
+    go _ [] = []
+    go currI (x:xs) =
+      let val = if currI == i then a else x in
+      val : go (currI + 1) xs
+
+-- FIXME: this should probably only be called by our code, because otherwise
+-- users could scuff up which sub-types they include for the main type.
+mkDecompose :: Name -> [Name] -> Q [Dec]
+mkDecompose unionName subNames = do
+    unionCons <- getConstructors unionName
+    subConss <- mapM getConstructors subNames
+    let subConIdxs = mconcat $ zipWith replicate (length <$> subConss) [0..]
+    clauses <- zipWithM mkClause unionCons $ zip subConIdxs (mconcat subConss)
+    return [SigD name ft, FunD name clauses]
+  where
+    name = mkName $ "decompose" ++ nameBase unionName
+    mkArrow t1 t2 = AppT (AppT ArrowT t1) t2
+    a = VarT $ mkName "a"
+    arrows = flip mkArrow a <$> ConT <$> subNames
+    ft = foldr mkArrow (mkArrow (ConT unionName) a) arrows
+    mkClause :: Con -> (Int, Con) -> Q Clause
+    mkClause (NormalC conNameU argsU) (i, (NormalC conNameS argsS)) = do
+        -- We assume argsU and argsS have been lined up correctly!
+        argNames <- mapM (const $ newName "a") argsU
+        _Pats <- mapM (const $ return . VarP $ mkName "_") subNames
+        let fPats = replace i (VarP $ mkName "f") _Pats
+        return $ Clause
+          (fPats ++ [ConP conNameU $ fmap VarP argNames])
+          (NormalB $ AppE (VarE $ mkName "f") $ foldl AppE (ConE conNameS) $ fmap VarE argNames)
+          []

--- a/src/UnionSums.hs
+++ b/src/UnionSums.hs
@@ -17,13 +17,13 @@ import Language.Haskell.TH
 --   the original type name suffix has been replaced with the name of the new
 --   type. E.g.
 --
---   data FooType = Foo1FooType | Foo2FooType
---   data BarType = BarBarType
---   unionSumTypes "FooBarType" [''FooType, ''BarType]
+--   data SubTypeA = FooSubTypeA Int | BarSubTypeA Char
+--   data SubTypeB = BazSubTypeB
+--   unionSumTypes "BigType" [''SubTypeA, ''SubTypeB]
 --
---   provides
+--   defines
 --
---   data FooBarType = Foo1FooBarType | Foo2FooBarType | BarFooBarType
+--   data BigType = FooBigType Int | BarBigType Char | BazBigType
 unionSumTypes :: String -> [Name] -> Q [Dec]
 unionSumTypes _ [] = return []
 unionSumTypes newNameStr typeNames =
@@ -42,6 +42,18 @@ unionSumTypes newNameStr typeNames =
           (changeSuffix typeName (mkName newNameStr) conName)
     modConstructor _ _ = fail "Unrecognised constructor pattern"
 
+-- | Produces a converter from a "smaller" sum type to a "bigger" sum type. It's
+--   required that the names of the constructors are suffixed with the type name
+--   and that the names of the constructors of the small and big types match
+--   once the suffixes have been removed. E.g.
+--
+--   mkConverter ''SubTypeA ''BigType
+--
+--   defines
+--
+--   subTypeAToBigType :: SubTypeA -> BigType
+--   subTypeAToBigType (FooSubTypeA i) = FooBigType i
+--   subTypeAToBigType (BarSubTypeA c) = FooBigType c
 mkConverter :: Name -> Name -> Q [Dec]
 mkConverter subName unionName = do
     ft <- [t| $(conT subName) -> $(conT unionName) |]
@@ -83,10 +95,21 @@ replace i a as = go 0 as
       let val = if currI == i then a else x in
       val : go (currI + 1) xs
 
--- FIXME: this should probably only be called by our code, because otherwise
--- users could scuff up which sub-types they include for the main type.
+-- | Produces a conversion function akin to `either` for converting "bigger"
+--   types into some other type via a value of their "smaller" type. E.g.
+--
+--   mkDecompose ''BigType [''SubTypeA, ''SubTypB]
+--
+--   defines
+--
+--   decomposeBigType :: (SubTypeA -> a) -> (SubTypeB -> a) -> BigType -> a
+--   decomposeBigType f _ (FooBigType i) = f (FooSubTypeA i)
+--   decomposeBigType f _ (BarBigType c) = f (BarSubTypeA c)
+--   decomposeBigType _ g BazBigType = g BazSubTypeB
 mkDecompose :: Name -> [Name] -> Q [Dec]
 mkDecompose unionName subNames = do
+    -- FIXME: this should probably only be called by our code, because otherwise
+    -- users could scuff up which sub-types they include for the main type.
     unionCons <- getConstructors unionName
     subConss <- mapM getConstructors subNames
     let subConIdxs = mconcat $ zipWith replicate (length <$> subConss) [0..]
@@ -106,5 +129,6 @@ mkDecompose unionName subNames = do
         let fPats = replace i (VarP $ mkName "f") _Pats
         return $ Clause
           (fPats ++ [ConP conNameU $ fmap VarP argNames])
-          (NormalB $ AppE (VarE $ mkName "f") $ foldl AppE (ConE conNameS) $ fmap VarE argNames)
+          (NormalB $ AppE (VarE $ mkName "f") $
+             foldl AppE (ConE conNameS) $ fmap VarE argNames)
           []

--- a/src/UnionSums.hs
+++ b/src/UnionSums.hs
@@ -125,7 +125,7 @@ mkDecompose unionName subNames = do
     mkClause (NormalC conNameU argsU) (i, (NormalC conNameS argsS)) = do
         -- We assume argsU and argsS have been lined up correctly!
         argNames <- mapM (const $ newName "a") argsU
-        _Pats <- mapM (const $ return . VarP $ mkName "_") subNames
+        _Pats <- mapM (const $ return WildP) subNames
         let fPats = replace i (VarP $ mkName "f") _Pats
         return $ Clause
           (fPats ++ [ConP conNameU $ fmap VarP argNames])

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,18 +1,1 @@
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE StandaloneDeriving #-}
-import UnionSums
-
-data FooType = Foo1FooType String | Foo2FooType deriving (Eq, Show)
-data BarType = BarBarType deriving (Eq, Show)
-unionSumTypes "FooBarType" [''FooType, ''BarType]
-deriving instance Show FooBarType
-deriving instance Eq FooBarType
-
-mkConverter ''FooType ''FooBarType
-mkConverter ''BarType ''FooBarType
-
-foo1 :: FooBarType
-foo1 = fooTypeToFooBarType $ Foo1FooType "bill"
-
-main :: IO ()
-main = putStrLn $ if foo1 /= BarFooBarType then "pass" else "fail"
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/test/UnionSumsSpec.hs
+++ b/test/UnionSumsSpec.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module UnionSumsSpec where
+
+import Test.Hspec
+
+import UnionSums
+
+
+data SubTypeA
+  = FooSubTypeA String
+  | BarSubTypeA
+  deriving (Eq, Show)
+
+data SubTypeB = BazSubTypeB deriving (Eq, Show)
+
+unionSumTypes "BigType" [''SubTypeA, ''SubTypeB]
+
+deriving instance Eq BigType
+deriving instance Show BigType
+
+mkConverter ''SubTypeA ''BigType
+mkConverter ''SubTypeB ''BigType
+
+mkDecompose ''BigType [''SubTypeA, ''SubTypeB]
+
+
+spec :: Spec
+spec = do
+  describe "type conversion" $ do
+    it "should convert small value to big value" $ do
+      subTypeAToBigType BarSubTypeA `shouldBe` BarBigType
+      subTypeAToBigType (FooSubTypeA "hello") `shouldBe` FooBigType "hello"
+      subTypeBToBigType BazSubTypeB `shouldBe` BazBigType
+
+    it "should allow conversion of big value via the smaller" $ do
+      decomposeBigType f g (FooBigType "world") `shouldBe` Just "world"
+      decomposeBigType f g BarBigType `shouldBe` Nothing
+      decomposeBigType f g BazBigType `shouldBe` Nothing
+      where
+        f (FooSubTypeA s) = Just s
+        f BarSubTypeA = Nothing
+        g BazSubTypeB = Nothing

--- a/test/UnionSumsSpec.hs
+++ b/test/UnionSumsSpec.hs
@@ -15,15 +15,18 @@ data SubTypeA
 
 data SubTypeB = BazSubTypeB deriving (Eq, Show)
 
-unionSumTypes "BigType" [''SubTypeA, ''SubTypeB]
+data SubTypeC = QuxSubTypeC deriving (Eq, Show)
+
+unionSumTypes "BigType" [''SubTypeA, ''SubTypeB, ''SubTypeC]
 
 deriving instance Eq BigType
 deriving instance Show BigType
 
 mkConverter ''SubTypeA ''BigType
 mkConverter ''SubTypeB ''BigType
+mkConverter ''SubTypeC ''BigType
 
-mkDecompose ''BigType [''SubTypeA, ''SubTypeB]
+mkDecompose ''BigType [''SubTypeA, ''SubTypeB, ''SubTypeC]
 
 
 spec :: Spec
@@ -33,12 +36,15 @@ spec = do
       subTypeAToBigType BarSubTypeA `shouldBe` BarBigType
       subTypeAToBigType (FooSubTypeA "hello") `shouldBe` FooBigType "hello"
       subTypeBToBigType BazSubTypeB `shouldBe` BazBigType
+      subTypeCToBigType QuxSubTypeC `shouldBe` QuxBigType
 
     it "should allow conversion of big value via the smaller" $ do
-      decomposeBigType f g (FooBigType "world") `shouldBe` Just "world"
-      decomposeBigType f g BarBigType `shouldBe` Nothing
-      decomposeBigType f g BazBigType `shouldBe` Nothing
+      decomposeBigType f g h (FooBigType "world") `shouldBe` Just "world"
+      decomposeBigType f g h BarBigType `shouldBe` Nothing
+      decomposeBigType f g h BazBigType `shouldBe` Nothing
+      decomposeBigType f g h QuxBigType `shouldBe` Nothing
       where
         f (FooSubTypeA s) = Just s
         f BarSubTypeA = Nothing
         g BazSubTypeB = Nothing
+        h QuxSubTypeC = Nothing

--- a/union-sums.cabal
+++ b/union-sums.cabal
@@ -27,7 +27,9 @@ test-suite union-sums-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   build-depends:       base
+                     , hspec
                      , union-sums
+  other-modules:       UnionSumsSpec
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 


### PR DESCRIPTION
Add the capability to convert from a "bigger" sum type into another value via one of it's constituents, just like `either :: (a -> c) -> (b -> c) -> Either a b -> c`.

Also improve the docs.

I can't figure out how to do all three splices (generating the "big" sum type, generating the functions from each "small" sum type to the "big" type, and generating the decomposition function) at the same time. This is annoying, because it means that users of the library can write incorrect code where they try to generate functions for types that don't actually line up.